### PR TITLE
Require implementors to share subscription publication technical details

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -366,6 +366,8 @@ Examples:
    - Supported notification triggers
    - Supported channel types
    - Supported payload types 
+   - Delivery guarantees (or lack thereof) pursuant to message delivery (e.g. "at least once", "at most once")
+   - Delivery guarantees (or lack thereof) with respect to ordering by time of occurrence 
 2. Servers SHOULD provide clear error messages when rejecting subscription requests due to unsupported features.
 
 ## 7. Additional Considerations


### PR DESCRIPTION
 While PUB-SUB or other implementation mechanisms would be inappropriate for the spec, the details would be of use for developers in determining how to work  against an implementation.